### PR TITLE
Mark the module as not zip safe.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     version='3.0.12a',
     description='Swagger UI blueprint for Flask',
     long_description=long_description,
+    zip_safe=False,
 
     url='https://github.com/sveint/flask-swagger-ui',
 


### PR DESCRIPTION
The template finder code in Flask doesn't handle zipped eggs well,
and thus won't find index.template.html.  This makes the module
crash when attempting to load the UI.