### PR TITLE
Make the name of the Blueprint configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ ENV/
 .ropeproject
 
 !flask_swagger_ui/dist/
+
+# PyCharm
+.idea/

--- a/flask_swagger_ui/flask_swagger_ui.py
+++ b/flask_swagger_ui/flask_swagger_ui.py
@@ -3,9 +3,15 @@ import json
 from flask import Blueprint, send_from_directory, render_template, request
 
 
-def get_swaggerui_blueprint(base_url, api_url, config=None, oauth_config=None):
+def get_swaggerui_blueprint(
+        base_url,
+        api_url,
+        config=None,
+        oauth_config=None,
+        blueprint_name='swagger_ui'
+):
 
-    swagger_ui = Blueprint('swagger_ui',
+    swagger_ui = Blueprint(blueprint_name,
                            __name__,
                            static_folder='dist',
                            template_folder='templates')


### PR DESCRIPTION
Loving this extension!

This little modification makes the name of the Blueprint a parameter.

I want to have a separate swagger UI endpoint for different versions of the API, e.g. `/v1/docs` and `/v2/docs`.

Blueprint names must be unique across all blueprints registered with the application.