### PR TITLE
Password protection added

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@ Simple Flask blueprint for adding [Swagger UI](https://github.com/swagger-api/sw
 
 Included Swagger UI version: 3.36.0.
 
+This fork added password protection to the swagger endpoint. 
+If you create an environment variable like,
+
+SWAGGER_PASSWORD=abc
+
+Then you will need to pass a query parameter in the URL like,
+
+http://mysite.com/swagger/?pass=abc
+
+If you dont have the environment variable then endpoint is not password protected and you can access it as per normal
+
+http://mysite.com/swagger/
+
 ## Installation
 
 `pip install flask-swagger-ui`

--- a/flask_swagger_ui/flask_swagger_ui.py
+++ b/flask_swagger_ui/flask_swagger_ui.py
@@ -1,26 +1,27 @@
 import os
 import json
-from flask import Blueprint, send_from_directory, render_template, request
+from flask import Blueprint, send_from_directory, render_template, request, jsonify
 
 
 def get_swaggerui_blueprint(
-    base_url, api_url, config=None, oauth_config=None, blueprint_name="swagger_ui"
+        base_url,
+        api_url,
+        config=None,
+        oauth_config=None,
+        blueprint_name='swagger_ui'
 ):
 
-    swagger_ui = Blueprint(
-        blueprint_name,
-        __name__,
-        static_folder="dist",
-        template_folder="templates",
-        url_prefix=base_url,
-    )
+    swagger_ui = Blueprint(blueprint_name,
+                           __name__,
+                           static_folder='dist',
+                           template_folder='templates')
 
     default_config = {
-        "app_name": "Swagger UI",
-        "dom_id": "#swagger-ui",
-        "url": api_url,
-        "layout": "StandaloneLayout",
-        "deepLinking": True,
+        'app_name': 'Swagger UI',
+        'dom_id': '#swagger-ui',
+        'url': api_url,
+        'layout': 'StandaloneLayout',
+        'deepLinking': True
     }
 
     if config:
@@ -28,33 +29,42 @@ def get_swaggerui_blueprint(
 
     fields = {
         # Some fields are used directly in template
-        "base_url": base_url,
-        "app_name": default_config.pop("app_name"),
+        'base_url': base_url,
+        'app_name': default_config.pop('app_name'),
         # Rest are just serialized into json string for inclusion in the .js file
-        "config_json": json.dumps(default_config),
+        'config_json': json.dumps(default_config),
+
     }
     if oauth_config:
-        fields["oauth_config_json"] = json.dumps(oauth_config)
+        fields['oauth_config_json'] = json.dumps(oauth_config)
 
-    @swagger_ui.route("/")
-    @swagger_ui.route("/<path:path>")
+    @swagger_ui.route('/')
+    @swagger_ui.route('/<path:path>')
     def show(path=None):
-        if not path or path == "index.html":
-            if not default_config.get("oauth2RedirectUrl", None):
+        if not path or path == 'index.html':
+            if not default_config.get('oauth2RedirectUrl', None):
                 default_config.update(
-                    {
-                        "oauth2RedirectUrl": os.path.join(
-                            request.base_url, "oauth2-redirect.html"
-                        )
-                    }
+                    {"oauth2RedirectUrl": os.path.join(
+                        request.base_url, "oauth2-redirect.html")}
                 )
-                fields["config_json"] = json.dumps(default_config)
-            return render_template("index.template.html", **fields)
+                fields['config_json'] = json.dumps(default_config)
+            # Added password protection via query parameter.
+            swagger_pass = os.getenv('SWAGGER_PASSWORD', default=None)
+            if swagger_pass:
+                user_pass = request.args.get('pass')
+                if swagger_pass != user_pass:
+                    response = jsonify({'error': 'password incorrect'})
+                    response.status_code = 401
+                    return response
+            return render_template('index.template.html', **fields)
         else:
             return send_from_directory(
                 # A bit of a hack to not pollute the default /static path with our files.
-                os.path.join(swagger_ui.root_path, swagger_ui._static_folder),
-                path,
+                os.path.join(
+                    swagger_ui.root_path,
+                    swagger_ui._static_folder
+                ),
+                path
             )
 
     return swagger_ui


### PR DESCRIPTION
I have added ability to password protect the swagger endpoint. If user decides to add a SWAGGER_PASSWORD environment variable, the endpoint will require user to pass in a query parameter (eg http://mysite.com?pass=abc) in order to access the swagger doc. This is useful when your API goes live, and you want to keep the swagger document available for your team but not have it open to anyone.