### PR TITLE
Added option to pass site url

### DIFF
--- a/flask_swagger_ui/flask_swagger_ui.py
+++ b/flask_swagger_ui/flask_swagger_ui.py
@@ -4,7 +4,7 @@ from flask import Blueprint, send_from_directory, render_template, request
 
 
 def get_swaggerui_blueprint(
-    base_url, api_url, config=None, oauth_config=None, blueprint_name="swagger_ui"
+    base_url, api_url, config=None, oauth_config=None, blueprint_name="swagger_ui", site_url=None
 ):
 
     swagger_ui = Blueprint(
@@ -25,6 +25,9 @@ def get_swaggerui_blueprint(
 
     if config:
         default_config.update(config)
+
+    if site_url is not None:
+        base_url = site_url + base_url
 
     fields = {
         # Some fields are used directly in template


### PR DESCRIPTION
I am using Caddy to route to the Flask API. If I run the flask on remote server, the UI throughs error like Mixed content error. So, if we pass the site url as the prefix with https, it will fix the error